### PR TITLE
Fix: Browser Accessbility

### DIFF
--- a/app/(components)/ColorModeSwitcher.tsx
+++ b/app/(components)/ColorModeSwitcher.tsx
@@ -32,7 +32,7 @@ export default function ColorModeSwitcher({width} : {width?: number}) {
   return (
     <label className="swap swap-rotate mx-4">
 
-      <input type="checkbox"/>
+      <input aria-label='color-mode-switcher-checkbox' type="checkbox"/>
 
       <svg className={`swap-on fill-current w-${width} h-${width}`} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" onClick={toggleMode}>
         <path

--- a/app/(components)/[semster]/LectureListItem.tsx
+++ b/app/(components)/[semster]/LectureListItem.tsx
@@ -67,7 +67,7 @@ export function LectureListItem({ lecture, isPending, detailsHref }: LectureList
 function LectureTypeIcon({ lecture }: { lecture: BasicLecture }) {
   if (!lecture?.type) return null
   const backgrounds = {
-    attendance: "bg-yellow-600",
+    attendance: "bg-yellow-700",
     noAttendance: "bg-green-700",
     volunatary: "bg-blue-700"
   }

--- a/app/(components)/[semster]/LectureListItem.tsx
+++ b/app/(components)/[semster]/LectureListItem.tsx
@@ -78,7 +78,7 @@ function LectureTypeIcon({ lecture }: { lecture: BasicLecture }) {
   if (lecture.type === "TU") background = backgrounds.volunatary
 
   return (
-    <div className={`text-white flex items-center absolute rounded-full py-2 px-2 shadow-xl ${background} left-4 -top-4`}>
+    <div className={`text-white flex items-center absolute rounded-full py-2 px-2 shadow-xl ${background} left-0 -top-0 -translate-y-1/4`}>
       <span className='text-xl font-bold px-1'>{lecture.type}</span>
     </div>
   )


### PR DESCRIPTION
This pull request resolves the following issues:
- Wrongful display of the lecture type background on Chrome and Safari (resolved using translate instead of -top-4)
- Missing input-label property for ColorModeSwitcher
- Constrast of the lecture-type component for lectures that require attendance. (made the background darker from bg-yellow-600  => bg-yellow-700)