### PR TITLE
Fix: Study Search Selection Route (from curriculum.details.skz to curriculum.id)

### DIFF
--- a/app/(components)/[study]/StudySearch.tsx
+++ b/app/(components)/[study]/StudySearch.tsx
@@ -26,8 +26,8 @@ export default function StudySearch({ studies, customization, iconOnly, semester
       return filtered.map((curriculum: Curricular) => ({
         title: curriculum.name,
         description: `Year: ${curriculum.details.version};  Estimation: ${curriculum.details.duration ?? '?'};  v${curriculum.details.ausgabe ? curriculum.details.ausgabe + ".0" : "?.?"}`,
-        route: `.../${curriculum.details.skz}`,
-        href: `/lectures/${curriculum.details.skz}/${semester}`
+        route: `.../${curriculum.id}`,
+        href: `/lectures/${curriculum.id}/${semester}`
       }))
     },
     sourceId: 'study-search'


### PR DESCRIPTION
Changed the route from curriculum.details.skz to curriculum.id as it is the case for the select button in the table.